### PR TITLE
Updated isaaclab env to use abs action space to control robot

### DIFF
--- a/src/lerobot/envs/isaaclab/environments/droid_environment.py
+++ b/src/lerobot/envs/isaaclab/environments/droid_environment.py
@@ -1,3 +1,5 @@
+import logging
+import os
 from pathlib import Path
 from typing import List
 
@@ -21,8 +23,8 @@ from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass, noise
 from pxr import Usd, UsdPhysics
 
-DATA_PATH = Path(__file__).parent / "../assets"
-print("Loading assets from:", DATA_PATH.resolve())
+DATA_PATH = Path(os.getenv("ISAAC_SIM_ASSETS", "/isaac-sim/kit/cache/custom_assets"))
+logging.info("Loading assets from:", DATA_PATH.resolve())  # noqa: F821
 
 
 @configclass

--- a/src/lerobot/envs/isaaclab/environments/droid_environment.py
+++ b/src/lerobot/envs/isaaclab/environments/droid_environment.py
@@ -24,7 +24,7 @@ from isaaclab.utils import configclass, noise
 from pxr import Usd, UsdPhysics
 
 DATA_PATH = Path(os.getenv("ISAAC_SIM_ASSETS", "/isaac-sim/kit/cache/custom_assets"))
-logging.info("Loading assets from:", DATA_PATH.resolve())  # noqa: F821
+logging.info(f"Loading assets from: {DATA_PATH.resolve()}")  # noqa: F821
 
 
 @configclass

--- a/src/lerobot/envs/isaaclab/isaaclab_env.py
+++ b/src/lerobot/envs/isaaclab/isaaclab_env.py
@@ -25,7 +25,7 @@ class IsaacLabEnv(LeRobotBaseEnv):
         # Therefore we save the observation images to self._render_images instead
 
         self._render_images = None
-        self._curr_state = None  # Used to store the current state for absolute action space conversion
+        self._current_state = None  # Used to store the current state for absolute action space conversion
         self._action_mask = torch.tensor(
             [True, True, True, True, True, True, True, False]
         ).to(
@@ -72,7 +72,7 @@ class IsaacLabEnv(LeRobotBaseEnv):
             "task": [task_description] * self.num_envs,
         }
 
-        self._curr_state = processed["observation.state"]
+        self._current_state = processed["observation.state"]
 
         return processed
 
@@ -142,7 +142,7 @@ class IsaacLabEnv(LeRobotBaseEnv):
         # Binarize the gripper + convert to absolute action space
         binarized_grip = (action[..., -1:] > 0.5).float()
         action = torch.cat([action[..., :-1], binarized_grip], dim=-1)
-        action = repack_delta_to_absolute(action, self._curr_state, self._action_mask)
+        action = repack_delta_to_absolute(action, self._current_state, self._action_mask)
 
         step_results = self.isaaclab_env.step(action)
         observation, reward, terminated, truncated, info = (

--- a/src/lerobot/scripts/convert_maniskill_datasets/replay_trajectory.py
+++ b/src/lerobot/scripts/convert_maniskill_datasets/replay_trajectory.py
@@ -4,7 +4,7 @@ https://github.com/haosulab/ManiSkill/blob/main/scripts/data_generation/replay_f
 Control Mode: pd_ee_delta_pose
 Observation State: qpos
 
-Demostration types:
+Demonstration types:
 - MP: Motion Planning
 - RL: RL policy
 

--- a/tests/envs/test_action_space_conversion.py
+++ b/tests/envs/test_action_space_conversion.py
@@ -1,0 +1,30 @@
+"""
+uv run pytest -s tests/envs/test_action_space_conversion.py
+"""
+
+import torch
+
+from lerobot.envs.isaaclab.isaaclab_env import repack_delta_to_absolute
+
+
+def test_repack_delta_to_absolute_batch():
+    actions = torch.tensor(
+        [[[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]], [[-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8]]]
+    )
+    state = torch.tensor([[[1, 2, 3, 4, 5, 6, 7, 100]], [[10, 20, 30, 40, 50, 60, 70, 200]]])
+
+    # Mask 1: update first 7 dimensions
+    mask1 = torch.tensor([True, True, True, True, True, True, True, False])
+    expected1 = torch.tensor(
+        [[[1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 0.8]], [[9.9, 19.8, 29.7, 39.6, 49.5, 59.4, 69.3, -0.8]]]
+    )
+    out1 = repack_delta_to_absolute(actions, state, mask1)
+    torch.testing.assert_close(out1, expected1, rtol=1e-4, atol=1e-6)
+
+    # Mask 2: update only dims 0 and 2
+    mask2 = torch.tensor([True, False, True, False, False, False, False, False])
+    expected2 = torch.tensor(
+        [[[1.1, 0.2, 3.3, 0.4, 0.5, 0.6, 0.7, 0.8]], [[9.9, -0.2, 29.7, -0.4, -0.5, -0.6, -0.7, -0.8]]]
+    )
+    out2 = repack_delta_to_absolute(actions, state, mask2)
+    torch.testing.assert_close(out2, expected2, rtol=1e-4, atol=1e-6)


### PR DESCRIPTION
## What this does
Converts relative joint pos to absolute joint position control mode in isaaclab simulation environments.

Examples:

```bash
uv run python src/lerobot/scripts/eval.py \
    --policy.type=pi0 \
    --policy.pretrained_path=brandonyang/pi0_droid \
    --policy.n_action_steps=10 \
    --env.type=isaaclab \
    --env.task="DROID" \
    --env.task_description="put banana in the bin" \
    --eval.n_episodes=1 \
    --eval.batch_size=1 \
    --policy.push_to_hub=false
```

https://github.com/user-attachments/assets/819c8226-7dc2-41d6-8dd2-f846305e34c8

https://github.com/user-attachments/assets/3084b65d-36b5-41e9-9d63-7784bdc50a18

https://github.com/user-attachments/assets/23627b72-e8b6-4072-914f-cad182d84a17

## How it was tested
- Added `test_repack_delta_to_absolute_batch` in `tests/env/test_action_space_conversion.py`