### PR TITLE
4 port huggingface transformers library over for pi0 paligemma modeling

### DIFF
--- a/src/lerobot/policies/pi0/conversion_scripts/openpi/src/openpi/policies/droid_policy.py
+++ b/src/lerobot/policies/pi0/conversion_scripts/openpi/src/openpi/policies/droid_policy.py
@@ -7,8 +7,10 @@ from lerobot.policies.pi0.conversion_scripts.openpi.src.openpi import transforms
 from lerobot.policies.pi0.conversion_scripts.openpi.src.openpi.models import model as _model
 
 
-def make_droid_example() -> dict:
-    """Creates a random input example for the Droid policy."""
+def make_droid_example(seed: int = None) -> dict:
+    if seed is not None:
+        np.random.seed(seed)
+
     return {
         "observation/exterior_image_1_left": np.random.randint(256, size=(224, 224, 3), dtype=np.uint8),
         "observation/wrist_image_left": np.random.randint(256, size=(224, 224, 3), dtype=np.uint8),

--- a/src/lerobot/policies/pi0/models/gemma.py
+++ b/src/lerobot/policies/pi0/models/gemma.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from transformers.activations import ACT2FN
+
+
+@dataclass
+class GemmaConfig:
+    _attn_implementation_autoset: bool = True
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    bos_token_id: int = 2
+    eos_token_id: int = 1
+    head_dim: int = 256
+    hidden_act: str = "gelu_pytorch_tanh"
+    hidden_activation: str = "gelu_pytorch_tanh"
+    hidden_size: int = 1024
+    initializer_range: float = 0.02
+    intermediate_size: int = 4096
+    max_position_embeddings: int = 8192
+    model_type: str = "gemma"
+    num_attention_heads: int = 8
+    num_hidden_layers: int = 18
+    num_key_value_heads: int = 1
+    num_image_tokens: int = 256
+    pad_token_id: int = 0
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    torch_dtype: str = "float32"
+    transformers_version: str = "4.50.3"
+    use_cache: bool = True
+    vocab_size: int = 257152
+
+
+class GemmaRMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.zeros(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float())
+        # Llama does x.to(float16) * w whilst Gemma is (x * w).to(float16)
+        # See https://github.com/huggingface/transformers/pull/29402
+        output = output * (1.0 + self.weight.float())
+        return output.type_as(x)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.eps}"
+
+
+class GemmaAttention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(self, config: GemmaConfig, layer_idx: int):
+        super().__init__()
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+
+        self.q_proj = nn.Linear(
+            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+        )
+
+
+class GemmaMLP(nn.Module):
+    def __init__(self, config: GemmaConfig):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return down_proj
+
+
+class GemmaDecoderLayer(nn.Module):
+    def __init__(self, config: GemmaConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = GemmaAttention(config=config, layer_idx=layer_idx)
+        self.mlp = GemmaMLP(config)
+        self.input_layernorm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+
+class GemmaModel(nn.Module):
+    def __init__(self, config: GemmaConfig):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
+        self.layers = nn.ModuleList(
+            [GemmaDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)

--- a/src/lerobot/policies/pi0/models/main.py
+++ b/src/lerobot/policies/pi0/models/main.py
@@ -1,0 +1,83 @@
+"""
+Adapted from Huggingface v0.50.3 transformers library.
+
+
+"""
+
+from dataclasses import dataclass, field
+
+import torch.nn as nn
+
+from lerobot.policies.pi0.models.gemma import GemmaConfig, GemmaModel
+from lerobot.policies.pi0.models.siglip import SiglipVisionConfig, SiglipVisionModel
+
+
+@dataclass
+class PaliGemmaConfig:
+    text_config: GemmaConfig = field(
+        default_factory=lambda: GemmaConfig(
+            _attn_implementation_autoset=True,
+            attention_bias=False,
+            attention_dropout=0.0,
+            bos_token_id=2,
+            eos_token_id=1,
+            head_dim=256,
+            hidden_act="gelu_pytorch_tanh",
+            hidden_activation="gelu_pytorch_tanh",
+            hidden_size=2048,
+            initializer_range=0.02,
+            intermediate_size=16384,
+            max_position_embeddings=8192,
+            model_type="gemma",
+            num_attention_heads=8,
+            num_hidden_layers=18,
+            num_image_tokens=256,
+            num_key_value_heads=1,
+            pad_token_id=0,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            torch_dtype="float32",
+            transformers_version="4.50.3",
+            use_cache=True,
+            vocab_size=257152,
+        )
+    )
+    vision_config: SiglipVisionConfig = field(default_factory=SiglipVisionConfig)
+
+
+class PaliGemmaMultiModalProjector(nn.Module):
+    def __init__(self, config: PaliGemmaConfig):
+        super().__init__()
+        self.linear = nn.Linear(
+            config.vision_config.hidden_size, config.vision_config.projection_dim, bias=True
+        )
+
+    def forward(self, image_features):
+        hidden_states = self.linear(image_features)
+        return hidden_states
+
+
+class PaliGemmaForConditionalGeneration(nn.Module):
+    def __init__(self, config: PaliGemmaConfig):
+        super().__init__()
+        self.config = config
+
+        self.vision_tower = SiglipVisionModel(config.vision_config)
+        self.multi_modal_projector = PaliGemmaMultiModalProjector(config)
+        self.language_model = GemmaForCausalLM(config=config.text_config)
+
+
+class GemmaForCausalLM(nn.Module):
+    def __init__(self, config: GemmaConfig):
+        super().__init__()
+        self.config = config
+
+        self.model = GemmaModel(config)
+
+
+if __name__ == "__main__":
+    paligemma_cfg = PaliGemmaConfig()
+    expert_cfg = GemmaConfig()
+
+    paligemma = PaliGemmaForConditionalGeneration(paligemma_cfg)
+    gemma_expert = GemmaForCausalLM(expert_cfg)

--- a/src/lerobot/policies/pi0/models/siglip.py
+++ b/src/lerobot/policies/pi0/models/siglip.py
@@ -142,7 +142,7 @@ class SiglipSdpaAttention(SiglipAttention):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         if output_attentions:
             # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
-            warnings.warn(
+            logging.warning(
                 "SiglipModel is using SiglipSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
                 'but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
             )

--- a/src/lerobot/policies/pi0/models/siglip.py
+++ b/src/lerobot/policies/pi0/models/siglip.py
@@ -142,7 +142,7 @@ class SiglipSdpaAttention(SiglipAttention):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         if output_attentions:
             # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
-            logging.warning_once(
+            warnings.warn(
                 "SiglipModel is using SiglipSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
                 'but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
             )

--- a/src/lerobot/policies/pi0/models/siglip.py
+++ b/src/lerobot/policies/pi0/models/siglip.py
@@ -1,0 +1,498 @@
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from transformers.activations import ACT2FN
+
+
+@dataclass
+class SiglipVisionConfig:
+    attn_implementation: str = "sdpa"
+    attention_dropout: float = 0.0
+    hidden_act: str = "gelu_pytorch_tanh"
+    hidden_size: int = 1152
+    image_size: int = 224
+    intermediate_size: int = 4304
+    layer_norm_eps: float = 1e-6
+    model_type: str = "siglip_vision_model"
+    num_attention_heads: int = 16
+    num_channels: int = 3
+    num_hidden_layers: int = 27
+    num_image_tokens: int = 256
+    patch_size: int = 14
+    projection_dim: int = 2048
+    projector_hidden_act: str = "gelu_fast"
+    torch_dtype: str = "float32"
+    transformers_version: str = "4.50.3"
+    vision_use_head: bool = False
+    ### Added ones
+    use_return_dict: bool = True
+    output_attentions: bool = False
+    output_hidden_states: bool = False
+
+
+def torch_int(x):
+    """
+    Casts an input to a torch int64 tensor if we are in a tracing context, otherwise to a Python int.
+    """
+    return x.to(torch.int64) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
+
+
+@dataclass
+class ModelOutput:
+    last_hidden_state: Optional[torch.FloatTensor] = None
+    pooler_output: Optional[torch.FloatTensor] = None
+    hidden_states: Optional[tuple[torch.FloatTensor, ...]] = None
+    attentions: Optional[tuple[torch.FloatTensor, ...]] = None
+
+
+class SiglipAttention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    # Copied from transformers.models.clip.modeling_clip.CLIPAttention.__init__
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(
+                f"embed_dim must be divisible by num_heads (got `embed_dim`: {self.embed_dim} and `num_heads`:"
+                f" {self.num_heads})."
+            )
+        self.scale = self.head_dim**-0.5
+        self.dropout = config.attention_dropout
+
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Input shape: Batch x Time x Channel"""
+
+        batch_size, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(batch_size, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(batch_size, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(batch_size, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+        k_v_seq_len = key_states.shape[-2]
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.scale
+
+        if attn_weights.size() != (batch_size, self.num_heads, q_len, k_v_seq_len):
+            raise ValueError(
+                f"Attention weights should be of size {(batch_size, self.num_heads, q_len, k_v_seq_len)}, but is"
+                f" {attn_weights.size()}"
+            )
+
+        if attention_mask is not None:
+            if attention_mask.size() != (batch_size, 1, q_len, k_v_seq_len):
+                raise ValueError(
+                    f"Attention mask should be of size {(batch_size, 1, q_len, k_v_seq_len)}, but is {attention_mask.size()}"
+                )
+            attn_weights = attn_weights + attention_mask
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(attn_weights, p=self.dropout, training=self.training)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (batch_size, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(batch_size, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(batch_size, q_len, self.embed_dim)
+
+        attn_output = self.out_proj(attn_output)
+
+        return attn_output, attn_weights
+
+
+class SiglipSdpaAttention(SiglipAttention):
+    """
+    Siglip attention module using torch.nn.functional.scaled_dot_product_attention. This module inherits from
+    `SiglipAttention` as the weights of the module stays untouched. The only changes are on the forward pass to adapt to
+    SDPA API.
+    """
+
+    is_causal = False
+
+    # Adapted from SiglipAttention.forward and transformers.models.llama.modeling_llama.LlamaSdpaAttention.forward
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if output_attentions:
+            # TODO: Improve this warning with e.g. `model.config.attn_implementation = "manual"` once this is implemented.
+            logging.warning_once(
+                "SiglipModel is using SiglipSdpaAttention, but `torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to the manual attention implementation, "
+                'but specifying the manual implementation will be required from Transformers version v5.0.0 onwards. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
+            )
+            return super().forward(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                output_attentions=output_attentions,
+            )
+
+        batch_size, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(batch_size, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(batch_size, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(batch_size, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+        # SDPA with memory-efficient backend is currently (torch==2.1.2) bugged with non-contiguous inputs with custom attn_mask,
+        # Reference: https://github.com/pytorch/pytorch/issues/112577.
+        if query_states.device.type == "cuda" and attention_mask is not None:
+            query_states = query_states.contiguous()
+            key_states = key_states.contiguous()
+            value_states = value_states.contiguous()
+
+        # We dispatch to SDPA's Flash Attention or Efficient kernels via this `is_causal` if statement instead of an inline conditional assignment
+        # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.
+        is_causal = bool(self.is_causal and q_len > 1)
+
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            attn_mask=attention_mask,
+            dropout_p=self.dropout if self.training else 0.0,
+            is_causal=is_causal,
+        )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.view(batch_size, q_len, self.embed_dim)
+
+        attn_output = self.out_proj(attn_output)
+
+        return attn_output, None
+
+
+SIGLIP_ATTENTION_CLASSES = {
+    "eager": SiglipAttention,
+    # "flash_attention_2": SiglipFlashAttention2,
+    "sdpa": SiglipSdpaAttention,
+}
+
+
+class SiglipMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.activation_fn = ACT2FN[config.hidden_act]
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states
+
+
+class SiglipEncoderLayer(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.self_attn = SIGLIP_ATTENTION_CLASSES[config.attn_implementation](config=config)
+        self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+        self.mlp = SiglipMLP(config)
+        self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
+
+    # Ignore copy
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.FloatTensor]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`):
+                Input to the layer of shape `(batch, seq_len, embed_dim)`.
+            attention_mask (`torch.FloatTensor`):
+                Attention mask of shape `(batch, 1, q_len, k_v_seq_len)` where padding elements are indicated by very large negative values.
+            output_attentions (`bool`, *optional*, defaults to `False`):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+        """
+        residual = hidden_states
+
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states, attn_weights = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            output_attentions=output_attentions,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (attn_weights,)
+
+        return outputs
+
+
+class SiglipEncoder(nn.Module):
+    """
+    Transformer encoder consisting of `config.num_hidden_layers` self attention layers. Each layer is a
+    [`SiglipEncoderLayer`].
+
+    Args:
+        config: SiglipConfig
+    """
+
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.config = config
+        self.layers = nn.ModuleList([SiglipEncoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.gradient_checkpointing = False
+
+    # Ignore copy
+    def forward(
+        self,
+        inputs_embeds,
+        attention_mask: Optional[torch.Tensor] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, ModelOutput]:
+        r"""
+        Args:
+            inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
+                Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation.
+                This is useful if you want more control over how to convert `input_ids` indices into associated vectors
+                than the model's internal embedding lookup matrix.
+            attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
+
+                - 1 for tokens that are **not masked**,
+                - 0 for tokens that are **masked**.
+
+                [What are attention masks?](../glossary#attention-mask)
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            output_hidden_states (`bool`, *optional*):
+                Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
+                for more detail.
+            return_dict (`bool`, *optional*):
+                Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+        """
+        output_attentions = (
+            output_attentions if output_attentions is not None else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        encoder_states = () if output_hidden_states else None
+        all_attentions = () if output_attentions else None
+
+        hidden_states = inputs_embeds
+        for encoder_layer in self.layers:
+            if output_hidden_states:
+                encoder_states = encoder_states + (hidden_states,)
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    encoder_layer.__call__,
+                    hidden_states,
+                    attention_mask,
+                    output_attentions,
+                )
+            else:
+                layer_outputs = encoder_layer(
+                    hidden_states,
+                    attention_mask,
+                    output_attentions=output_attentions,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_attentions = all_attentions + (layer_outputs[1],)
+
+        if output_hidden_states:
+            encoder_states = encoder_states + (hidden_states,)
+
+        if not return_dict:
+            return tuple(v for v in [hidden_states, encoder_states, all_attentions] if v is not None)
+        return ModelOutput(
+            last_hidden_state=hidden_states, hidden_states=encoder_states, attentions=all_attentions
+        )
+
+
+class SiglipVisionEmbeddings(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            padding="valid",
+        )
+
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.num_positions = self.num_patches
+        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
+        self.register_buffer(
+            "position_ids", torch.arange(self.num_positions).expand((1, -1)), persistent=False
+        )
+
+    def interpolate_pos_encoding(self, embeddings: torch.Tensor, height: int, width: int) -> torch.Tensor:
+        """
+        This method allows to interpolate the pre-trained position encodings, to be able to use the model on higher resolution
+        images. This method is also adapted to support torch.jit tracing and no class embeddings.
+
+        Adapted from:
+        - https://github.com/facebookresearch/dino/blob/de9ee3df6cf39fac952ab558447af1fa1365362a/vision_transformer.py#L174-L194, and
+        - https://github.com/facebookresearch/dinov2/blob/e1277af2ba9496fbadf7aec6eba56e8d882d1e35/dinov2/models/vision_transformer.py#L179-L211
+        """
+
+        num_patches = embeddings.shape[1]
+        num_positions = self.position_embedding.weight.shape[0]
+
+        # always interpolate when tracing to ensure the exported model works for dynamic input shapes
+        if not torch.jit.is_tracing() and num_patches == num_positions and height == width:
+            return self.position_embedding(self.position_ids)
+
+        patch_pos_embed = self.position_embedding.weight.unsqueeze(0)
+
+        dim = embeddings.shape[-1]
+
+        new_height = height // self.patch_size
+        new_width = width // self.patch_size
+
+        sqrt_num_positions = torch_int(num_positions**0.5)
+        patch_pos_embed = patch_pos_embed.reshape(1, sqrt_num_positions, sqrt_num_positions, dim)
+        patch_pos_embed = patch_pos_embed.permute(0, 3, 1, 2)
+
+        patch_pos_embed = nn.functional.interpolate(
+            patch_pos_embed,
+            size=(new_height, new_width),
+            mode="bicubic",
+            align_corners=False,
+        )
+
+        patch_pos_embed = patch_pos_embed.permute(0, 2, 3, 1).view(1, -1, dim)
+        return patch_pos_embed
+
+    def forward(self, pixel_values: torch.FloatTensor, interpolate_pos_encoding=False) -> torch.Tensor:
+        _, _, height, width = pixel_values.shape
+        target_dtype = self.patch_embedding.weight.dtype
+        patch_embeds = self.patch_embedding(
+            pixel_values.to(dtype=target_dtype)
+        )  # shape = [*, width, grid, grid]
+        embeddings = patch_embeds.flatten(2).transpose(1, 2)
+
+        if interpolate_pos_encoding:
+            embeddings = embeddings + self.interpolate_pos_encoding(embeddings, height, width)
+        else:
+            embeddings = embeddings + self.position_embedding(self.position_ids)
+        return embeddings
+
+
+class SiglipVisionTransformer(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.config = config
+        embed_dim = config.hidden_size
+
+        self.embeddings = SiglipVisionEmbeddings(config)
+        self.encoder = SiglipEncoder(config)
+        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+
+    def forward(
+        self,
+        pixel_values,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        interpolate_pos_encoding: Optional[bool] = False,
+    ) -> Union[Tuple, ModelOutput]:
+        output_attentions = (
+            output_attentions if output_attentions is not None else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        hidden_states = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
+
+        encoder_outputs = self.encoder(
+            inputs_embeds=hidden_states,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        last_hidden_state = encoder_outputs.last_hidden_state
+        last_hidden_state = self.post_layernorm(last_hidden_state)
+
+        return ModelOutput(
+            last_hidden_state=last_hidden_state,
+            pooler_output=None,
+            hidden_states=encoder_outputs.hidden_states,
+            attentions=encoder_outputs.attentions,
+        )
+
+
+class SiglipVisionModel(nn.Module):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.config = config
+        self.vision_model = SiglipVisionTransformer(config)
+
+    def forward(
+        self,
+        pixel_values,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        interpolate_pos_encoding: bool = False,
+    ) -> Union[Tuple, ModelOutput]:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        return self.vision_model(
+            pixel_values=pixel_values,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            interpolate_pos_encoding=interpolate_pos_encoding,
+        )

--- a/src/lerobot/policies/pi0/paligemma_with_expert.py
+++ b/src/lerobot/policies/pi0/paligemma_with_expert.py
@@ -74,7 +74,6 @@ class PaliGemmaWithExpertConfig:
         )
 
     def __post_init__(self):
-        super().__post_init__()
         if self.train_expert_only and not self.freeze_vision_encoder:
             raise ValueError(
                 "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."

--- a/tests/policies/pi0/test_compare_paligemma.py
+++ b/tests/policies/pi0/test_compare_paligemma.py
@@ -1,0 +1,163 @@
+"""
+uv run pytest -sv tests/policies/pi0/test_compare_paligemma.py
+
+This test compares PaliGemmaForConditionalGeneration and GemmaForCausalLM models to ensure the
+custom version is consistent with the original Huggingface implementation.
+
+transformers==4.50.3
+
+"""
+
+import pytest
+import torch
+from transformers import (
+    GemmaForCausalLM as HFGemmaForCausalLM,
+)
+from transformers import (
+    PaliGemmaForConditionalGeneration as HFPaliGemmaForConditionalGeneration,
+)
+from transformers.models.auto import CONFIG_MAPPING
+
+from lerobot.policies.pi0.models.gemma import GemmaConfig
+from lerobot.policies.pi0.models.main import (
+    GemmaForCausalLM,
+    PaliGemmaConfig,
+    PaliGemmaForConditionalGeneration,
+)
+from tests.utils import DEVICE
+
+
+@pytest.fixture(scope="module")
+def hf_paligemma_model():
+    paligemma_config = CONFIG_MAPPING["paligemma"](
+        transformers_version="4.48.1",
+        _vocab_size=257152,
+        bos_token_id=2,
+        eos_token_id=1,
+        hidden_size=2048,
+        image_token_index=257152,
+        model_type="paligemma",
+        pad_token_id=0,
+        projection_dim=2048,
+        text_config={
+            "hidden_activation": "gelu_pytorch_tanh",
+            "hidden_size": 2048,
+            "intermediate_size": 16384,
+            "model_type": "gemma",
+            "num_attention_heads": 8,
+            "num_hidden_layers": 18,
+            "num_image_tokens": 256,
+            "num_key_value_heads": 1,
+            "torch_dtype": "float32",
+            "vocab_size": 257152,
+        },
+        vision_config={
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "model_type": "siglip_vision_model",
+            "num_attention_heads": 16,
+            "num_hidden_layers": 27,
+            "num_image_tokens": 256,
+            "patch_size": 14,
+            "projection_dim": 2048,
+            "projector_hidden_act": "gelu_fast",
+            "torch_dtype": "float32",
+            "vision_use_head": False,
+        },
+    )
+    paligemma = HFPaliGemmaForConditionalGeneration(paligemma_config)
+    return paligemma.to(DEVICE)
+
+
+@pytest.fixture(scope="module")
+def hf_gemma_model():
+    gemma_expert_config = CONFIG_MAPPING["gemma"](
+        attention_bias=False,
+        attention_dropout=0.0,
+        bos_token_id=2,
+        eos_token_id=1,
+        head_dim=256,
+        hidden_act="gelu_pytorch_tanh",
+        hidden_activation="gelu_pytorch_tanh",
+        hidden_size=1024,
+        initializer_range=0.02,
+        intermediate_size=4096,
+        max_position_embeddings=8192,
+        model_type="gemma",
+        num_attention_heads=8,
+        num_hidden_layers=18,
+        num_key_value_heads=1,
+        pad_token_id=0,
+        rms_norm_eps=1e-06,
+        rope_theta=10000.0,
+        torch_dtype="float32",
+        transformers_version="4.48.1",
+        use_cache=True,
+        vocab_size=257152,
+    )
+    gemma_expert = HFGemmaForCausalLM(config=gemma_expert_config)
+    return gemma_expert.to(DEVICE)
+
+
+@pytest.fixture(scope="module")
+def paligemma_model(hf_paligemma_model):
+    model = PaliGemmaForConditionalGeneration(PaliGemmaConfig()).to(DEVICE)
+    model.load_state_dict(hf_paligemma_model.state_dict(), strict=False)
+    return model
+
+
+@pytest.fixture(scope="module")
+def gemma_model(hf_gemma_model):
+    model = GemmaForCausalLM(GemmaConfig()).to(DEVICE)
+    model.load_state_dict(hf_gemma_model.state_dict(), strict=False)
+    return model
+
+
+def test_compare_paligemma_and_gemma(
+    hf_paligemma_model: HFPaliGemmaForConditionalGeneration,
+    hf_gemma_model: HFGemmaForCausalLM,
+    paligemma_model: PaliGemmaForConditionalGeneration,
+    gemma_model: GemmaForCausalLM,
+):
+    """
+    Compare the Huggingface PaliGemmaForConditionalGeneration and GemmaForCausalLM models with custom implementations.
+    """
+    assert isinstance(hf_paligemma_model, HFPaliGemmaForConditionalGeneration)
+    assert isinstance(hf_gemma_model, HFGemmaForCausalLM)
+
+    assert isinstance(paligemma_model, PaliGemmaForConditionalGeneration)
+    assert isinstance(gemma_model, GemmaForCausalLM)
+
+    hf_paligemma_state_dict = hf_paligemma_model.state_dict()
+    paligemma_state_dict = paligemma_model.state_dict()
+
+    hf_gemma_state_dict = hf_gemma_model.state_dict()
+    gemma_state_dict = gemma_model.state_dict()
+
+    assert paligemma_state_dict.keys() <= hf_paligemma_state_dict.keys(), (
+        "Custom PaliGemma model has keys not present in the HF version"
+    )
+
+    assert gemma_state_dict.keys() <= hf_gemma_state_dict.keys(), (
+        "Custom Gemma model has keys not present in the HF version"
+    )
+
+
+def test_vision_tower(
+    hf_paligemma_model: HFPaliGemmaForConditionalGeneration,
+    hf_gemma_model: HFGemmaForCausalLM,
+    paligemma_model: PaliGemmaForConditionalGeneration,
+    gemma_model: GemmaForCausalLM,
+):
+    pixel_values = torch.randn(1, 3, 224, 224).to(DEVICE)
+    hf_paligemma_outputs = hf_paligemma_model.vision_tower(pixel_values=pixel_values)
+    paligemma_outputs = paligemma_model.vision_tower(pixel_values=pixel_values)
+    feature = paligemma_outputs.last_hidden_state
+    hf_feature = hf_paligemma_outputs.last_hidden_state
+
+    torch.testing.assert_close(hf_feature, feature, rtol=1e-5, atol=1e-8)
+
+    proj_features = paligemma_model.multi_modal_projector(feature)
+    hf_proj_features = hf_paligemma_model.multi_modal_projector(hf_feature)
+
+    torch.testing.assert_close(proj_features, hf_proj_features, rtol=1e-5, atol=1e-8)

--- a/tests/policies/pi0/test_compare_pi0_droid.py
+++ b/tests/policies/pi0/test_compare_pi0_droid.py
@@ -129,7 +129,7 @@ def lerobot_pi0(monkeypatch, dummy_dataset_metadata):
 
 @pytest.fixture
 def get_policy_inputs():
-    openpi_example = droid_policy.make_droid_example()
+    openpi_example = droid_policy.make_droid_example(seed=42)
     lerobot_batch = {}
 
     def _preprocess_image(img: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
### Summary

- Created two wrapper classes to keep module structure:
  ```python
  class PaliGemmaForConditionalGeneration(nn.Module):
      def __init__(self, config: PaliGemmaConfig):
          super().__init__()
          self.config = config
  
          self.vision_tower = SiglipVisionModel(config.vision_config)
          self.multi_modal_projector = PaliGemmaMultiModalProjector(config)
          self.language_model = GemmaForCausalLM(config=config.text_config)
  
  
  class GemmaForCausalLM(nn.Module):
      def __init__(self, config: GemmaConfig):
          super().__init__()
          self.config = config
  
          self.model = GemmaModel(config)
  ```
- Ported over `SiglipVisionModel`, `PaliGemmaMultiModalProjector`, `GemmaForCausalLM` from hf transformers==4.50.3. Removed any hf dependency for low level abstractions for these classes. (All of these are nn.modules)
- Created default dataclass config definitions `PaliGemmaConfig`, `GemmaConfig`, `SiglipVisionConfig` that correspond to original hf implementations. 

### Testing
- Created `tests/policies/pi0/test_compare_paligemma.py` to make sure ported implementations match original hf implementations.
- Pass all tests in `test/policies/pi0`.

### WIP
None

### Future work
- [ ] Remove unnecessary fields in config files copied over from hf.
- [ ] Maybe create a separate inference model definition to speed things up? Maybe we could write pure torch models that can benefit from JIT.